### PR TITLE
Phase 6.1 — CMake File API ingestion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# ---- Export compile_commands for tooling
+# ---- Export compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ---- Default build type for single-config generators
@@ -24,7 +24,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
 endif()
 
-# ---- Project-wide warnings (target-based)
+# ---- Warnings
 add_library(depbridge_warnings INTERFACE)
 
 if(MSVC)
@@ -52,14 +52,19 @@ else()
   endif()
 endif()
 
-# ---- Sanitizers (best-effort, clang/gcc)
+# ---- Sanitizers (best-effort)
 add_library(depbridge_sanitizers INTERFACE)
 if(DEPB_ENABLE_SANITIZERS AND NOT MSVC)
-  target_compile_options(depbridge_sanitizers INTERFACE -fsanitize=address,undefined -fno-omit-frame-pointer)
-  target_link_options(depbridge_sanitizers INTERFACE -fsanitize=address,undefined)
+  target_compile_options(depbridge_sanitizers INTERFACE
+    -fsanitize=address,undefined
+    -fno-omit-frame-pointer
+  )
+  target_link_options(depbridge_sanitizers INTERFACE
+    -fsanitize=address,undefined
+  )
 endif()
 
-# ---- LTO (IPO)
+# ---- LTO / IPO
 include(CheckIPOSupported)
 if(DEPB_ENABLE_LTO)
   check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
@@ -70,11 +75,9 @@ if(DEPB_ENABLE_LTO)
   endif()
 endif()
 
-# ---- Dependencies (keep minimal)
-# Prefer package managers (vcpkg/conan) to provide these.
+# ---- Dependencies
 find_package(fmt CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-# Optional: CLI11
 find_package(CLI11 CONFIG QUIET)
 
 # ---- Core library
@@ -83,21 +86,29 @@ add_library(depbridge::core ALIAS depbridge_core)
 
 target_sources(depbridge_core
   PRIVATE
+    # Phase 3–4
     src/model/ids.cpp
     src/model/normalize.cpp
-    src/cmake/file_api_reader.cpp
-    src/cmake/target_graph_builder.cpp
+
+    # Phase 5
     src/sbom/cyclonedx_writer.cpp
-    src/github/dependency_submission.cpp
+
+    # Phase 6
+    src/ingest/ingest.cpp
+    src/ingest/cmake/file_api_ingestor.cpp
+
   PUBLIC
-      PUBLIC
+    # Model
     include/depbridge/model/types.hpp
     include/depbridge/model/ids.hpp
     include/depbridge/model/normalize.hpp
-    include/depbridge/cmake/file_api_reader.hpp
-    include/depbridge/cmake/target_graph_builder.hpp
+
+    # SBOM
     include/depbridge/sbom/cyclonedx_writer.hpp
-    include/depbridge/github/dependency_submission.hpp
+
+    # Ingestion
+    include/depbridge/ingest/ingest.hpp
+    include/depbridge/ingest/cmake/file_api_ingestor.hpp
 )
 
 target_include_directories(depbridge_core
@@ -122,13 +133,12 @@ if(TARGET CLI11::CLI11)
   target_link_libraries(depbridge PRIVATE CLI11::CLI11)
   target_compile_definitions(depbridge PRIVATE DEPB_HAS_CLI11=1)
 else()
-  # You can still implement a tiny argument parser yourself for MVP
   target_compile_definitions(depbridge PRIVATE DEPB_HAS_CLI11=0)
 endif()
 
 target_link_libraries(depbridge PRIVATE depbridge::core)
 
-# ---- Testing
+# ---- Tests
 include(CTest)
 if(DEPB_BUILD_TESTS)
   enable_testing()

--- a/include/depbridge/ingest/cmake/file_api_ingestor.hpp
+++ b/include/depbridge/ingest/cmake/file_api_ingestor.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "depbridge/ingest/ingest.hpp"
+
+namespace depbridge::ingest::cmake
+{
+
+    model::ProjectGraph ingest_file_api(const std::filesystem::path &build_dir,
+                                        const IngestOptions &options);
+
+}

--- a/include/depbridge/ingest/ingest.hpp
+++ b/include/depbridge/ingest/ingest.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "depbridge/model/types.hpp"
+
+#include <filesystem>
+
+namespace depbridge::ingest
+{
+
+    struct IngestOptions
+    {
+        bool include_tests = false;
+        bool include_toolchain_targets = false;
+        bool include_generated_targets = false;
+    };
+
+    model::ProjectGraph ingest(const std::filesystem::path &build_dir,
+                               const IngestOptions &options = {});
+
+}

--- a/include/depbridge/version.hpp
+++ b/include/depbridge/version.hpp
@@ -1,4 +1,5 @@
 #pragma once
-namespace depbridge {
-inline constexpr const char* version = "0.1.0-dev";
+namespace depbridge
+{
+    inline constexpr const char *version = "0.1.0-core";
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,7 +1,31 @@
-#include <iostream>
-#include "depbridge/version.hpp"
+#include "depbridge/ingest/ingest.hpp"
+#include "depbridge/model/normalize.hpp"
+#include "depbridge/sbom/cyclonedx_writer.hpp"
 
-int main(int, char**) {
-    std::cout << "cpp-dep-bridge " << depbridge::version << "\n";
-    return 0;
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        if (argc != 3 || std::string(argv[1]) != "scan")
+        {
+            std::cerr << "Usage: depbridge scan <build-dir>\n";
+            return 1;
+        }
+
+        const std::string build_dir = argv[2];
+
+        auto graph = depbridge::ingest::ingest(build_dir);
+        depbridge::model::normalize_graph(graph);
+        depbridge::sbom::write_cyclonedx_json(std::cout, graph);
+
+        return 0;
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "depbridge error: " << e.what() << "\n";
+        return 2;
+    }
 }

--- a/src/ingest/cmake/file_api_ingestor.cpp
+++ b/src/ingest/cmake/file_api_ingestor.cpp
@@ -1,0 +1,130 @@
+#include "depbridge/ingest/cmake/file_api_ingestor.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+namespace depbridge::ingest::cmake
+{
+
+    using json = nlohmann::json;
+    using namespace depbridge::model;
+    namespace fs = std::filesystem;
+
+    static json load_json(const fs::path &p)
+    {
+        std::ifstream f(p);
+        if (!f)
+        {
+            throw std::runtime_error("Failed to open JSON file: " + p.string());
+        }
+        json j;
+        f >> j;
+        return j;
+    }
+
+    static fs::path find_reply_dir(const fs::path &build_dir)
+    {
+        fs::path reply = build_dir / ".cmake" / "api" / "v1" / "reply";
+        if (!fs::exists(reply))
+        {
+            throw std::runtime_error(
+                "CMake File API reply directory not found: " + reply.string());
+        }
+        return reply;
+    }
+
+    static fs::path find_index(const fs::path &reply_dir)
+    {
+        for (const auto &e : fs::directory_iterator(reply_dir))
+        {
+            const auto name = e.path().filename().string();
+            if (name.rfind("index-", 0) == 0 && e.path().extension() == ".json")
+            {
+                return e.path();
+            }
+        }
+        throw std::runtime_error("CMake File API index-*.json not found");
+    }
+
+    ProjectGraph ingest_file_api(const fs::path &build_dir,
+                                 const IngestOptions &)
+    {
+        ProjectGraph g;
+
+        g.context.run_id = "cmake-file-api";
+        g.context.root_directory = build_dir.string();
+        g.context.build_directory = build_dir.string();
+
+        const fs::path reply_dir = find_reply_dir(build_dir);
+        const fs::path index_path = find_index(reply_dir);
+        const json index = load_json(index_path);
+
+        fs::path codemodel_path;
+        for (const auto &obj : index.at("objects"))
+        {
+            if (obj.at("kind") == "codemodel" &&
+                obj.at("version").at("major") == 2)
+            {
+                codemodel_path = reply_dir / obj.at("jsonFile").get<std::string>();
+                break;
+            }
+        }
+
+        if (codemodel_path.empty())
+        {
+            throw std::runtime_error("codemodel-v2 not found in File API index");
+        }
+
+        const json codemodel = load_json(codemodel_path);
+
+        for (const auto &cfg : codemodel.at("configurations"))
+        {
+            const std::string cfg_name = cfg.at("name").get<std::string>();
+
+            for (const auto &tgt_ref : cfg.at("targets"))
+            {
+                const fs::path tgt_path =
+                    reply_dir / tgt_ref.at("jsonFile").get<std::string>();
+                const json tgt = load_json(tgt_path);
+
+                BuildTarget bt;
+                bt.name = tgt.at("name").get<std::string>();
+                bt.id = TargetId{"raw:" + bt.name + ":" + cfg_name};
+
+                bt.sources.push_back(SourceRef{
+                    "cmake",
+                    "target/" + bt.name,
+                    std::nullopt});
+
+                g.targets.emplace(bt.id.value, bt);
+
+                if (tgt.contains("link"))
+                {
+                    const auto &link = tgt.at("link");
+                    if (link.contains("libraries"))
+                    {
+                        for (const auto &lib : link.at("libraries"))
+                        {
+                            DependencyEdge e;
+                            e.from = bt.id;
+                            e.raw = lib.get<std::string>();
+
+                            e.sources.push_back(SourceRef{
+                                "cmake",
+                                "linkLibraries",
+                                std::nullopt});
+
+                            g.edges.push_back(e);
+                        }
+                    }
+                }
+            }
+        }
+
+        return g;
+    }
+
+}

--- a/src/ingest/ingest.cpp
+++ b/src/ingest/ingest.cpp
@@ -1,0 +1,13 @@
+#include "depbridge/ingest/ingest.hpp"
+#include "depbridge/ingest/cmake/file_api_ingestor.hpp"
+
+namespace depbridge::ingest
+{
+
+    model::ProjectGraph ingest(const std::filesystem::path &build_dir,
+                               const IngestOptions &options)
+    {
+        return cmake::ingest_file_api(build_dir, options);
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR introduces real CMake File API ingestion (Phase 6.1) and a minimal CLI entry point, enabling cpp-dep-bridge to ingest actual CMake build directories and produce a deterministic CycloneDX SBOM.

This is a foundational infrastructure PR: it completes the ingestion layer and proves the end-to-end pipeline on real builds, while intentionally deferring dependency resolution heuristics to the next phase.