### PR TITLE
v0.4.0-alpha: deterministic CMake File API ingestion, evidence-gated …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(depbridge_core
     src/model/ids.cpp
     src/model/normalize.cpp
     src/model/classify.cpp
+    src/model/evidence.cpp
 
     # Phase 5
     src/sbom/cyclonedx_writer.cpp
@@ -108,6 +109,7 @@ target_sources(depbridge_core
     include/depbridge/model/ids.hpp
     include/depbridge/model/normalize.hpp
     include/depbridge/model/classify.hpp
+    include/depbridge/model/evidence.hpp
     include/depbridge/model/filter.hpp
     include/depbridge/model/variant_normalize.hpp
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture
+
+## Phase contracts (v0.4.0-alpha)
+
+The pipeline is intentionally layered. Each phase consumes typed model data and emits explicit evidence.
+
+1. **Ingestion (CMake File API)**
+   - Inputs: CMake File API reply JSON files.
+   - Outputs: `ProjectGraph.targets`, raw `DependencyEdge.raw`, optional `DependencyEdge.to_target`, and `SourceRef` evidence.
+   - Contract: ingestion records raw build facts only. No package-name guessing from paths in default mode.
+
+2. **Normalization**
+   - Inputs: raw edge tokens + target references.
+   - Outputs: `Component`s, `DependencyEdge.to_component`, normalized names, preserved raw evidence.
+   - Contract: imported targets normalize to package-level identities (e.g., `fmt::fmt` -> `fmt`) while preserving original imported token evidence.
+
+3. **Classification**
+   - Inputs: components + evidence.
+   - Outputs: `Component.origin`.
+   - Contract: evidence-gated classification only. Insufficient evidence remains `unknown`.
+
+4. **Filtering**
+   - Inputs: classified graph.
+   - Outputs: pruned graph by policy.
+
+5. **SBOM emission**
+   - Inputs: filtered graph.
+   - Outputs: deterministic CycloneDX JSON components + dependencies + metadata.
+
+## Evidence contract
+
+`SourceRef` remains the transport object between phases. Classification and policy logic are keyed through `EvidenceKind` adapters, not ad hoc free-form string checks.
+
+## Breaking behavior changes in v0.4.0-alpha
+
+- Imported target component identities are package-level.
+- Default pipeline removes ingestion-time package-manager guessing.
+- Classification is conservative and defaults to `unknown` unless explicit evidence exists.
+- CycloneDX output includes deterministic `dependencies` and metadata subject when resolvable.

--- a/docs/classification-normalization-model.md
+++ b/docs/classification-normalization-model.md
@@ -1,236 +1,28 @@
-# Classification & Normalization Model
+# Classification & Normalization Model (v0.4.0-alpha)
 
-This document defines the **conceptual model, rules, and precedence** used by **cpp-dep-bridge** to turn raw build data into a deterministic dependency graph and SBOM.
+## Normalization
 
-It is the *source of truth* for how components are normalized, classified, filtered, and emitted.
+- Preserve raw link-token evidence (`cmake-link-token`) and path evidence (`cmake-link-path`).
+- Imported targets normalize to package-level component names.
+  - `fmt::fmt` -> component `fmt`
+  - Original imported token is preserved as evidence (`cmake-imported`).
+- Path-based normalization may strip platform naming conventions when path context exists.
+- Ambiguous non-path tokens are not aggressively collapsed.
 
----
+## Classification
 
-## 1. Core Concepts
+Classification is evidence-gated and conservative.
 
-### 1.1 Build Targets
-
-A **BuildTarget** represents a CMake target as seen by the CMake File API.
-
-Examples:
-- `depbridge_core`
-- `fmt::fmt`
-- `ALL_BUILD` (generator-provided)
-
-Targets are **not** SBOM components by default.
-They are *sources of evidence* that produce dependencies.
-
----
-
-### 1.2 Components
-
-A **Component** represents a real dependency that may appear in an SBOM.
-
-Each component has:
-- a **stable ComponentId**
-- a **normalized name**
-- a **type** (library, executable, tool, system, …)
-- an **origin** (project-local, third-party, system, unknown)
-- supporting **evidence** (`SourceRef`s)
-
-Components are derived from:
-- linker tokens
-- imported targets
-- library paths
-
----
-
-## 2. Normalization Model
-
-Normalization happens **before classification**.
-
-### 2.1 Token Normalization
-
-Raw linker tokens are normalized as follows:
-
-| Input | Normalized Name |
-|------|------------------|
-| `-lfmt` | `fmt` |
-| `D:/vcpkg/.../fmtd.lib` | `fmt` |
-| `fmt::fmt` | `fmt` |
-| `libssl.so` | `ssl` |
+Order:
+1. `project_local`
+2. `system`
+3. `third_party`
+4. `unknown`
 
 Rules:
-- path separators normalized
-- extensions stripped (`.lib`, `.a`, `.so`, `.dylib`)
-- `lib` prefix stripped on Unix
-- debug suffixes (`d`) stripped when detected
-
----
-
-### 2.2 Imported Targets
-
-Imported CMake targets (`foo::bar`) are **collapsed** into a single component:
-
-- canonical name: namespace (`foo`)
-- original target preserved as evidence
-
-This ensures:
-- `fmt::fmt` → `fmt`
-- no duplication between target-based and path-based detection
-
----
-
-### 2.3 Component Identity
-
-Component identity is derived from **semantic fields only**:
-
-```
-(type, namespace, name, version, purl)
-```
-
-Build variants (Debug/Release) **do not affect identity**.
-
----
-
-## 3. Classification Model
-
-Classification assigns a **ComponentOrigin**.
-
-### 3.1 Origins
-
-| Origin | Meaning |
-|------|--------|
-| `project_local` | Built by the current project |
-| `third_party` | External dependency |
-| `system` | OS / toolchain provided |
-| `unknown` | Insufficient evidence |
-
----
-
-### 3.2 Classification Precedence (STRICT)
-
-Classification is applied in this exact order:
-
-1. **Project-local**
-2. **System**
-3. **Third-party**
-4. **Unknown** (default)
-
-Once a component is classified, **it is never downgraded**.
-
----
-
-### 3.3 Project-local Classification
-
-A component is `project_local` if:
-
-- its name matches a build target
-- OR it originates from a project build artifact
-
-Evidence sources:
-- `BuildTarget`
-- local artifact paths
-
----
-
-### 3.4 System Classification
-
-A component is `system` if:
-
-- its name matches known system libraries
-  - `kernel32`, `user32`, `pthread`, `dl`, …
-- OR it originates from system include/lib directories
-
-System classification **does not override project-local**.
-
----
-
-### 3.5 Third-party Classification
-
-A component is `third_party` if:
-
-- it originates from a package manager path
-  - vcpkg
-  - Conan
-- OR it is an imported CMake target
-- OR it has an explicit third-party `SourceRef`
-
-Third-party classification **does not override project-local or system**.
-
----
-
-## 4. Filtering Model
-
-Filtering is applied **after classification**.
-
-Filter options:
-
-| Option | Effect |
-|------|-------|
-| `include_system` | Keep system components |
-| `include_project_local` | Keep project-local components |
-
-Filtering:
-- removes components
-- prunes edges pointing to removed components
-
----
-
-## 5. Build-Variant Normalization
-
-Build variants (Debug / Release):
-
-- do **not** create separate components
-- are detected and collapsed
-- may be recorded as evidence only
-
-Examples:
-- `fmtd.lib` + `fmt.lib` → single `fmt` component
-
----
-
-## 6. SBOM Emission
-
-The CycloneDX writer:
-
-- emits **only normalized components**
-- emits one component per ComponentId
-- preserves origin as a property
-
-Example:
-
-```json
-{
-  "name": "fmt",
-  "type": "library",
-  "properties": [
-    { "name": "depbridge:origin", "value": "third-party" }
-  ]
-}
-```
-
----
-
-## 7. Guarantees
-
-cpp-dep-bridge guarantees:
-
-- deterministic output
-- stable component identity
-- no duplicate components
-- conservative classification
-
----
-
-## 8. Non-Goals
-
-This model intentionally does **not**:
-
-- guess versions without evidence
-- infer licenses heuristically
-- merge unrelated libraries
-- rewrite build graphs
-
----
-
-## 9. Status
-
-Applies starting with **v0.3.0-alpha**.
-Future releases may *extend* but not break this model.
-
+- `project_local`: explicit target-name match evidence.
+- `system`: known system names + explicit link evidence.
+- `third_party`: explicit package-manager/imported-target evidence.
+- No explicit evidence => remain `unknown`.
+
+This model prevents over-classification and avoids silent guessing.

--- a/docs/determinism-contract.md
+++ b/docs/determinism-contract.md
@@ -1,0 +1,20 @@
+# Determinism Contract (v0.4.0-alpha)
+
+## Ordering rules
+
+- File API index selection: choose lexicographically greatest `index-*.json` filename.
+- Components: sorted by `ComponentId` for SBOM emission.
+- CycloneDX dependencies:
+  - dependency objects sorted by `ref` (component id),
+  - each `dependsOn` list sorted lexicographically.
+
+## Identity and collision policy
+
+- Component IDs are derived from canonical identity keys.
+- Rebuild/merge code verifies canonical-key consistency when IDs collide.
+- Silent merge is forbidden when canonical keys differ.
+
+## Prohibited nondeterminism sources
+
+- Filesystem mtime-based selection.
+- Iteration-order dependence from unordered containers without sorting at output boundaries.

--- a/docs/release-notes-v0.4.0-alpha.md
+++ b/docs/release-notes-v0.4.0-alpha.md
@@ -1,0 +1,15 @@
+# v0.4.0-alpha Release Notes (draft)
+
+## Behavior changes
+
+1. Imported CMake targets normalize to package-level component identity.
+2. Classification is evidence-gated and falls back to `unknown` for ambiguous cases.
+3. Default ingestion no longer performs package-manager guessing from library paths.
+4. CycloneDX output now includes deterministic `dependencies`.
+5. CycloneDX metadata tool version is wired to `depbridge::version` and includes metadata subject when resolvable.
+
+## Migration notes
+
+- Expect component-id shifts for imported-target-heavy graphs.
+- Expect fewer automatic `third_party`/`system` classifications without explicit evidence.
+- SBOM consumers should handle populated `dependencies` and metadata subject.

--- a/include/depbridge/ingest/cmake/file_api_ingestor.hpp
+++ b/include/depbridge/ingest/cmake/file_api_ingestor.hpp
@@ -2,8 +2,12 @@
 
 #include "depbridge/ingest/ingest.hpp"
 
+#include <vector>
+
 namespace depbridge::ingest::cmake
 {
+
+    std::filesystem::path select_deterministic_file_api_index(const std::vector<std::filesystem::path> &candidates);
 
     model::ProjectGraph ingest_file_api(const std::filesystem::path &build_dir,
                                         const IngestOptions &options);

--- a/include/depbridge/model/evidence.hpp
+++ b/include/depbridge/model/evidence.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "depbridge/model/types.hpp"
+
+namespace depbridge::model
+{
+    enum class EvidenceKind
+    {
+        unknown,
+        cmake_link_token,
+        cmake_link_path,
+        cmake_target,
+        cmake_target_id,
+        cmake_imported_target,
+        package_manager,
+        package_manager_path,
+        system_library_name,
+        project_target_match
+    };
+
+    EvidenceKind evidence_kind_from_source(const SourceRef &source);
+}

--- a/include/depbridge/model/ids.hpp
+++ b/include/depbridge/model/ids.hpp
@@ -36,4 +36,7 @@ namespace depbridge::model
 
     ComponentId component_id_of(const Component &c);
 
+    std::string canonical_component_key_of(const Component &c);
+
+
 }

--- a/include/depbridge/version.hpp
+++ b/include/depbridge/version.hpp
@@ -1,5 +1,5 @@
 #pragma once
 namespace depbridge
 {
-    inline constexpr const char *version = "v0.3.0-alpha";
+    inline constexpr const char *version = "v0.4.0-alpha";
 }

--- a/src/ingest/cmake/file_api_ingestor.cpp
+++ b/src/ingest/cmake/file_api_ingestor.cpp
@@ -2,15 +2,14 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <string>
-#include <string_view>
-#include <vector>
 #include <unordered_map>
-#include <cctype>
-#include <optional>
+#include <vector>
 
 namespace depbridge::ingest::cmake
 {
@@ -34,8 +33,7 @@ namespace depbridge::ingest::cmake
         }
         catch (const std::exception &e)
         {
-            throw std::runtime_error(
-                "Failed to parse JSON file '" + p.string() + "': " + e.what());
+            throw std::runtime_error("Failed to parse JSON file '" + p.string() + "': " + e.what());
         }
     }
 
@@ -44,15 +42,31 @@ namespace depbridge::ingest::cmake
         fs::path reply = build_dir / ".cmake" / "api" / "v1" / "reply";
         if (!fs::exists(reply))
         {
-            throw std::runtime_error(
-                "CMake File API reply directory not found: " + reply.string());
+            throw std::runtime_error("CMake File API reply directory not found: " + reply.string());
         }
         if (!fs::is_directory(reply))
         {
-            throw std::runtime_error(
-                "CMake File API reply path is not a directory: " + reply.string());
+            throw std::runtime_error("CMake File API reply path is not a directory: " + reply.string());
         }
         return reply;
+    }
+
+    fs::path select_deterministic_file_api_index(const std::vector<fs::path> &candidates)
+    {
+        if (candidates.empty())
+        {
+            throw std::runtime_error("No index file candidates provided");
+        }
+
+        std::vector<std::string> names;
+        names.reserve(candidates.size());
+        for (const auto &candidate : candidates)
+        {
+            names.push_back(candidate.filename().string());
+        }
+
+        std::sort(names.begin(), names.end());
+        return candidates.front().parent_path() / names.back();
     }
 
     static fs::path find_index(const fs::path &reply_dir)
@@ -72,114 +86,10 @@ namespace depbridge::ingest::cmake
 
         if (candidates.empty())
         {
-            throw std::runtime_error(
-                "CMake File API index-*.json not found in reply directory: " + reply_dir.string());
+            throw std::runtime_error("CMake File API index-*.json not found in reply directory: " + reply_dir.string());
         }
 
-        fs::path best = candidates.front();
-        auto best_time = fs::last_write_time(best);
-
-        for (std::size_t i = 1; i < candidates.size(); ++i)
-        {
-            const fs::path &candidate = candidates[i];
-            const auto candidate_time = fs::last_write_time(candidate);
-
-            if (candidate_time > best_time ||
-                (candidate_time == best_time && candidate.filename().string() > best.filename().string()))
-            {
-                best = candidate;
-                best_time = candidate_time;
-            }
-        }
-
-        return best;
-    }
-
-    static std::string to_lower_ascii(std::string s)
-    {
-        for (char &ch : s)
-        {
-            if (ch >= 'A' && ch <= 'Z')
-                ch = static_cast<char>(ch - 'A' + 'a');
-        }
-        return s;
-    }
-
-    static std::string normalize_slashes(std::string s)
-    {
-        for (char &ch : s)
-        {
-            if (ch == '\\')
-                ch = '/';
-        }
-        return s;
-    }
-
-    static bool ends_with(std::string_view s, std::string_view suf)
-    {
-        return s.size() >= suf.size() && s.substr(s.size() - suf.size()) == suf;
-    }
-
-    static std::string basename_noext(std::string_view p)
-    {
-        const auto pos = p.find_last_of("/\\");
-        std::string base = (pos == std::string_view::npos) ? std::string(p) : std::string(p.substr(pos + 1));
-        auto dot = base.find_last_of('.');
-        if (dot != std::string::npos)
-            base = base.substr(0, dot);
-        return base;
-    }
-
-    struct VcpkgHit
-    {
-        std::string triplet;
-        std::string port; // best-effort guess from lib name
-        bool is_debug = false;
-        std::string normalized_path;
-    };
-
-    static std::optional<VcpkgHit> detect_vcpkg_from_lib_path(std::string_view raw_path)
-    {
-        std::string p = normalize_slashes(std::string(raw_path));
-        std::string pl = to_lower_ascii(p);
-
-        const std::string needle = "/installed/";
-        auto pos = pl.find(needle);
-        if (pos == std::string::npos)
-            return std::nullopt;
-
-        auto triplet_begin = pos + needle.size();
-        auto triplet_end = pl.find('/', triplet_begin);
-        if (triplet_end == std::string::npos || triplet_end == triplet_begin)
-            return std::nullopt;
-
-        const std::string triplet = p.substr(triplet_begin, triplet_end - triplet_begin);
-
-        bool is_debug = (pl.find("/debug/lib/") != std::string::npos);
-
-        if (!(ends_with(pl, ".lib") ||
-              ends_with(pl, ".a") ||
-              ends_with(pl, ".so") ||
-              ends_with(pl, ".dylib")))
-        {
-            return std::nullopt;
-        }
-
-        std::string libname = basename_noext(p);
-
-        if (is_debug && libname.size() > 1 && (libname.back() == 'd' || libname.back() == 'D'))
-        {
-            libname.pop_back();
-        }
-
-        std::string port = to_lower_ascii(libname);
-
-        VcpkgHit hit;
-        hit.triplet = triplet;
-        hit.port = port;
-        hit.is_debug = is_debug;
-        hit.normalized_path = p;
-        return hit;
+        return select_deterministic_file_api_index(candidates);
     }
 
     static bool is_noise_token(const std::string &s)
@@ -271,8 +181,7 @@ namespace depbridge::ingest::cmake
                           const std::string &raw,
                           const std::string &ref,
                           const std::unordered_map<std::string, TargetId> &cmake_id_to_target,
-                          const std::unordered_map<std::string, TargetId> &cmake_name_to_target,
-                          const std::vector<SourceRef> &extra_sources = {})
+                          const std::unordered_map<std::string, TargetId> &cmake_name_to_target)
     {
         if (is_noise_token(raw))
             return;
@@ -283,8 +192,6 @@ namespace depbridge::ingest::cmake
         e.to_target = resolve_target_token(cfg_name, raw, cmake_id_to_target, cmake_name_to_target);
 
         e.sources.push_back(SourceRef{"cmake", ref, std::nullopt});
-        for (const auto &s : extra_sources)
-            e.sources.push_back(s);
 
         g.edges.push_back(std::move(e));
     }
@@ -331,8 +238,7 @@ namespace depbridge::ingest::cmake
 
                 for (const auto &tgt_ref : cfg.at("targets"))
                 {
-                    const fs::path tgt_path =
-                        reply_dir / tgt_ref.at("jsonFile").get<std::string>();
+                    const fs::path tgt_path = reply_dir / tgt_ref.at("jsonFile").get<std::string>();
 
                     try
                     {
@@ -347,35 +253,25 @@ namespace depbridge::ingest::cmake
                                                           ? tgt.at("id").get<std::string>()
                                                           : std::string{};
 
-                        bt.sources.push_back(SourceRef{
-                            "cmake",
-                            "target/" + bt.name,
-                            std::nullopt});
+                        bt.sources.push_back(SourceRef{"cmake", "target/" + bt.name, std::nullopt});
 
                         if (!cmake_tid.empty())
                         {
-                            bt.sources.push_back(SourceRef{
-                                "cmake-target-id",
-                                cmake_tid,
-                                std::nullopt});
+                            bt.sources.push_back(SourceRef{"cmake-target-id", cmake_tid, std::nullopt});
 
-                            const auto [_, inserted] = cmake_id_to_target.emplace(
-                                make_cfg_key(cfg_name, cmake_tid), bt.id);
+                            const auto [_, inserted] = cmake_id_to_target.emplace(make_cfg_key(cfg_name, cmake_tid), bt.id);
                             if (!inserted)
                             {
-                                throw std::runtime_error(
-                                    "Duplicate CMake target id mapping: '" + cmake_tid +
-                                    "' in configuration '" + cfg_name + "'");
+                                throw std::runtime_error("Duplicate CMake target id mapping: '" + cmake_tid +
+                                                         "' in configuration '" + cfg_name + "'");
                             }
                         }
 
-                        const auto [__, inserted_name] = cmake_name_to_target.emplace(
-                            make_cfg_key(cfg_name, bt.name), bt.id);
+                        const auto [__, inserted_name] = cmake_name_to_target.emplace(make_cfg_key(cfg_name, bt.name), bt.id);
                         if (!inserted_name)
                         {
-                            throw std::runtime_error(
-                                "Duplicate target name mapping: '" + bt.name +
-                                "' in configuration '" + cfg_name + "'");
+                            throw std::runtime_error("Duplicate target name mapping: '" + bt.name +
+                                                     "' in configuration '" + cfg_name + "'");
                         }
 
                         const bool is_generator = tgt.contains("isGeneratorProvided") &&
@@ -385,18 +281,14 @@ namespace depbridge::ingest::cmake
 
                         if (!is_generator && !has_artifacts)
                         {
-                            bt.sources.push_back(SourceRef{
-                                "cmake-imported",
-                                bt.name,
-                                std::nullopt});
+                            bt.sources.push_back(SourceRef{"cmake-imported", bt.name, std::nullopt});
                         }
 
                         const auto [___, inserted_target] = g.targets.emplace(bt.id.value, bt);
                         if (!inserted_target)
                         {
-                            throw std::runtime_error(
-                                "Duplicate build target id insertion: '" + bt.id.value +
-                                "' in configuration '" + cfg_name + "'");
+                            throw std::runtime_error("Duplicate build target id insertion: '" + bt.id.value +
+                                                     "' in configuration '" + cfg_name + "'");
                         }
 
                         if (!tgt.contains("link"))
@@ -410,29 +302,18 @@ namespace depbridge::ingest::cmake
                             {
                                 if (lib.is_string())
                                 {
-                                    push_edge(g, bt.id, cfg_name, lib.get<std::string>(), "link.libraries",
-                                              cmake_id_to_target, cmake_name_to_target);
+                                    push_edge(g, bt.id, cfg_name, lib.get<std::string>(), "link.libraries", cmake_id_to_target, cmake_name_to_target);
                                 }
                                 else if (lib.is_object())
                                 {
                                     if (lib.contains("name") && lib.at("name").is_string())
                                     {
-                                        push_edge(g, bt.id, cfg_name, lib.at("name").get<std::string>(), "link.libraries.name",
-                                                  cmake_id_to_target, cmake_name_to_target);
+                                        push_edge(g, bt.id, cfg_name, lib.at("name").get<std::string>(), "link.libraries.name", cmake_id_to_target, cmake_name_to_target);
                                     }
                                     else if (lib.contains("path") && lib.at("path").is_string())
                                     {
                                         const std::string p = lib.at("path").get<std::string>();
-
-                                        std::vector<SourceRef> extra;
-                                        if (auto hit = detect_vcpkg_from_lib_path(p))
-                                        {
-                                            extra.push_back(SourceRef{"vcpkg", "guess:" + hit->port + ":" + hit->triplet, std::nullopt});
-                                            extra.push_back(SourceRef{"vcpkg-path", hit->normalized_path, std::nullopt});
-                                        }
-
-                                        push_edge(g, bt.id, cfg_name, p, "link.libraries.path",
-                                                  cmake_id_to_target, cmake_name_to_target, extra);
+                                        push_edge(g, bt.id, cfg_name, p, "link.libraries.path", cmake_id_to_target, cmake_name_to_target);
                                     }
                                 }
                             }
@@ -448,45 +329,28 @@ namespace depbridge::ingest::cmake
                                     continue;
 
                                 const std::string fragment = frag.at("fragment").get<std::string>();
-                                const std::string role = (frag.contains("role") && frag.at("role").is_string())
-                                                             ? frag.at("role").get<std::string>()
-                                                             : std::string{};
 
                                 for (const auto &tok : split_ws(fragment))
                                 {
-                                    std::vector<SourceRef> extra;
-                                    if (role == "libraries")
-                                    {
-                                        if (auto hit = detect_vcpkg_from_lib_path(tok))
-                                        {
-                                            extra.push_back(SourceRef{"vcpkg", "guess:" + hit->port + ":" + hit->triplet, std::nullopt});
-                                            extra.push_back(SourceRef{"vcpkg-path", hit->normalized_path, std::nullopt});
-                                        }
-                                    }
-
-                                    push_edge(g, bt.id, cfg_name, tok, "link.commandFragments.fragment",
-                                              cmake_id_to_target, cmake_name_to_target, extra);
+                                    push_edge(g, bt.id, cfg_name, tok, "link.commandFragments.fragment", cmake_id_to_target, cmake_name_to_target);
                                 }
                             }
                         }
                     }
                     catch (const std::exception &e)
                     {
-                        throw std::runtime_error(
-                            "Failed while processing target file '" + tgt_path.string() +
-                            "' at stage 'target processing': " + e.what());
+                        throw std::runtime_error("Failed while processing target file '" + tgt_path.string() +
+                                                 "' at stage 'target processing': " + e.what());
                     }
                 }
             }
         }
         catch (const std::exception &e)
         {
-            throw std::runtime_error(
-                "Failed while processing codemodel file '" + codemodel_path.string() +
-                "' at stage 'codemodel processing': " + e.what());
+            throw std::runtime_error("Failed while processing codemodel file '" + codemodel_path.string() +
+                                     "' at stage 'codemodel processing': " + e.what());
         }
 
         return g;
     }
-
 }

--- a/src/model/classify.cpp
+++ b/src/model/classify.cpp
@@ -1,7 +1,7 @@
 #include "depbridge/model/classify.hpp"
+#include "depbridge/model/evidence.hpp"
 
 #include <unordered_set>
-#include <string_view>
 
 namespace depbridge::model
 {
@@ -22,58 +22,43 @@ namespace depbridge::model
             if (target_names.find(c.name) != target_names.end())
             {
                 c.origin = ComponentOrigin::project_local;
+                c.sources.push_back(SourceRef{"project-target", c.name, std::nullopt});
             }
         }
     }
-
 }
 
 namespace depbridge::model
 {
     namespace
     {
-
 #if defined(_WIN32)
-
         const std::unordered_set<std::string> system_libs = {
-            "kernel32",
-            "user32",
-            "gdi32",
-            "advapi32",
-            "shell32",
-            "ole32",
-            "oleaut32",
-            "uuid",
-            "winspool",
-            "comdlg32",
-            "ws2_32",
-            "bcrypt",
-            "crypt32"};
-
+            "kernel32", "user32", "gdi32", "advapi32", "shell32", "ole32", "oleaut32",
+            "uuid", "winspool", "comdlg32", "ws2_32", "bcrypt", "crypt32"};
 #elif defined(__linux__)
-
         const std::unordered_set<std::string> system_libs = {
-            "c",
-            "m",
-            "dl",
-            "pthread",
-            "rt",
-            "gcc_s",
-            "stdc++"};
-
+            "c", "m", "dl", "pthread", "rt", "gcc_s", "stdc++"};
 #elif defined(__APPLE__)
-
         const std::unordered_set<std::string> system_libs = {
-            "System",
-            "objc",
-            "c++"};
-
+            "System", "objc", "c++"};
 #else
-
         const std::unordered_set<std::string> system_libs = {};
-
 #endif
 
+        bool has_explicit_system_evidence(const Component &c)
+        {
+            for (const auto &s : c.sources)
+            {
+                const auto kind = evidence_kind_from_source(s);
+                if (kind == EvidenceKind::cmake_link_token || kind == EvidenceKind::cmake_link_path ||
+                    kind == EvidenceKind::system_library_name)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     void classify_system_components(ProjectGraph &g)
@@ -83,32 +68,35 @@ namespace depbridge::model
             if (c.origin != ComponentOrigin::unknown)
                 continue;
 
+            if (!has_explicit_system_evidence(c))
+                continue;
+
             if (system_libs.find(c.name) != system_libs.end())
             {
                 c.origin = ComponentOrigin::system;
+                c.sources.push_back(SourceRef{"system-lib", c.name, std::nullopt});
             }
         }
     }
-
 }
 
 namespace depbridge::model
 {
     namespace
     {
-        bool is_imported_target(std::string_view name)
+        bool has_explicit_third_party_evidence(const Component &c)
         {
-            return name.find("::") != std::string_view::npos;
-        }
-
-        bool is_third_party_source(const SourceRef &s)
-        {
-            static const std::unordered_set<std::string> systems = {
-                "vcpkg",
-                "conan",
-                "fetchcontent",
-                "cmake-imported"};
-            return systems.find(s.system) != systems.end();
+            for (const auto &s : c.sources)
+            {
+                const auto kind = evidence_kind_from_source(s);
+                if (kind == EvidenceKind::cmake_imported_target ||
+                    kind == EvidenceKind::package_manager ||
+                    kind == EvidenceKind::package_manager_path)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -119,21 +107,10 @@ namespace depbridge::model
             if (c.origin != ComponentOrigin::unknown)
                 continue;
 
-            if (is_imported_target(c.name))
+            if (has_explicit_third_party_evidence(c))
             {
                 c.origin = ComponentOrigin::third_party;
-                continue;
-            }
-
-            for (const auto &s : c.sources)
-            {
-                if (is_third_party_source(s))
-                {
-                    c.origin = ComponentOrigin::third_party;
-                    break;
-                }
             }
         }
     }
-
 }

--- a/src/model/evidence.cpp
+++ b/src/model/evidence.cpp
@@ -1,0 +1,31 @@
+#include "depbridge/model/evidence.hpp"
+
+#include <string_view>
+
+namespace depbridge::model
+{
+    EvidenceKind evidence_kind_from_source(const SourceRef &source)
+    {
+        if (source.system == "cmake-link-token")
+            return EvidenceKind::cmake_link_token;
+        if (source.system == "cmake-link-path")
+            return EvidenceKind::cmake_link_path;
+        if (source.system == "cmake")
+            return EvidenceKind::cmake_target;
+        if (source.system == "cmake-target-id")
+            return EvidenceKind::cmake_target_id;
+        if (source.system == "cmake-imported")
+            return EvidenceKind::cmake_imported_target;
+        if (source.system == "system-lib")
+            return EvidenceKind::system_library_name;
+        if (source.system == "project-target")
+            return EvidenceKind::project_target_match;
+
+        if (source.system == "vcpkg" || source.system == "conan")
+            return EvidenceKind::package_manager;
+        if (source.system == "vcpkg-path" || source.system == "conan-path")
+            return EvidenceKind::package_manager_path;
+
+        return EvidenceKind::unknown;
+    }
+}

--- a/src/model/ids.cpp
+++ b/src/model/ids.cpp
@@ -169,4 +169,14 @@ namespace depbridge::model
             c.purl.value_or(std::string{}));
     }
 
+    std::string canonical_component_key_of(const Component &c)
+    {
+        return canonical_component_key(
+            c.type,
+            c.namespace_.value_or(std::string{}),
+            c.name,
+            c.version.value_or(std::string{}),
+            c.purl.value_or(std::string{}));
+    }
+
 }

--- a/src/model/normalize.cpp
+++ b/src/model/normalize.cpp
@@ -1,9 +1,11 @@
 #include "depbridge/model/normalize.hpp"
 #include "depbridge/model/ids.hpp"
+#include "depbridge/model/evidence.hpp"
 
 #include <algorithm>
 #include <cctype>
 #include <unordered_map>
+#include <stdexcept>
 
 namespace depbridge::model
 {
@@ -168,7 +170,7 @@ namespace depbridge::model
         c.type = ComponentType::library;
 
         const std::string tok = normalize_token(raw_token);
-        c.sources.push_back(SourceRef{"link-token", tok, std::nullopt});
+        c.sources.push_back(SourceRef{"cmake-link-token", tok, std::nullopt});
 
         if (tok.empty())
         {
@@ -189,6 +191,7 @@ namespace depbridge::model
         {
             const std::string p = normalize_path(tok);
             c.name = normalize_lib_name_from_file(p, opt);
+            c.sources.push_back(SourceRef{"cmake-link-path", p, std::nullopt});
             c.id = make_component_id(c.type, "", c.name, "", "");
             return c;
         }
@@ -196,11 +199,11 @@ namespace depbridge::model
         if (is_imported_cmake_target(tok))
         {
             c.type = ComponentType::library;
-            c.name = tok;
+            c.name = imported_target_namespace(tok);
 
             c.properties.emplace("cmake.target", tok);
             c.properties.emplace("cmake.target.namespace", imported_target_namespace(tok));
-            c.sources.push_back(SourceRef{"cmake", "imported-target", std::nullopt});
+            c.sources.push_back(SourceRef{"cmake-imported", tok, std::nullopt});
 
             c.id = make_component_id(c.type, "", c.name, "", "");
             return c;
@@ -211,7 +214,6 @@ namespace depbridge::model
             name = strip_ext(name, opt);
             if (opt.case_fold_windows_libs)
                 name = to_lower_ascii(name);
-            name = strip_unix_libprefix(name, opt);
             c.name = name;
             c.id = make_component_id(c.type, "", c.name, "", "");
             return c;
@@ -326,7 +328,9 @@ namespace depbridge::model
 
                     if (bt.name.find("::") != std::string::npos)
                     {
-                        c.name = bt.name;
+                        c.name = imported_target_namespace(bt.name);
+                        c.properties["cmake.target"] = bt.name;
+                        c.sources.push_back(SourceRef{"cmake-imported", bt.name, std::nullopt});
                     }
 
                     append_sources(c.sources, bt.sources);
@@ -369,6 +373,14 @@ namespace depbridge::model
             }
             else
             {
+                const std::string existing_key = canonical_component_key_of(it->second);
+                const std::string incoming_key = canonical_component_key_of(comp);
+                if (existing_key != incoming_key)
+                {
+                    throw std::runtime_error(
+                        "Component identity collision detected for id '" + new_key +
+                        "' with differing canonical keys");
+                }
                 merge_component(it->second, comp);
             }
         }

--- a/src/sbom/cyclonedx_writer.cpp
+++ b/src/sbom/cyclonedx_writer.cpp
@@ -1,6 +1,10 @@
 #include "depbridge/sbom/cyclonedx_writer.hpp"
 
+#include "depbridge/version.hpp"
+
 #include <algorithm>
+#include <map>
+#include <set>
 
 namespace depbridge::sbom
 {
@@ -9,7 +13,6 @@ namespace depbridge::sbom
 
     namespace
     {
-
         std::string json_escape(const std::string &s)
         {
             std::string out;
@@ -69,6 +72,21 @@ namespace depbridge::sbom
             return "library";
         }
 
+        std::optional<const Component *> resolve_metadata_subject(const ProjectGraph &g)
+        {
+            for (const auto &[_, t] : g.targets)
+            {
+                for (const auto &[__, c] : g.components)
+                {
+                    if (c.name == t.name)
+                    {
+                        return &c;
+                    }
+                }
+            }
+            return std::nullopt;
+        }
+
     } // namespace
 
     void write_cyclonedx_json(std::ostream &os, const ProjectGraph &g)
@@ -80,11 +98,36 @@ namespace depbridge::sbom
             comps.push_back(&c);
         }
 
-        std::sort(comps.begin(), comps.end(),
-                  [](const Component *a, const Component *b)
-                  {
-                      return a->id.value < b->id.value;
-                  });
+        std::sort(comps.begin(), comps.end(), [](const Component *a, const Component *b)
+                  { return a->id.value < b->id.value; });
+
+        std::map<std::string, std::set<std::string>> dependencies;
+        std::map<std::string, std::set<std::string>> target_to_components;
+
+        for (const auto &edge : g.edges)
+        {
+            if (edge.to_component)
+            {
+                target_to_components[edge.from.value].insert(edge.to_component->value);
+            }
+        }
+
+        for (const auto &[target_id, dep_components] : target_to_components)
+        {
+            const auto target_it = g.targets.find(target_id);
+            if (target_it == g.targets.end())
+                continue;
+
+            for (const auto &[_, component] : g.components)
+            {
+                if (component.name != target_it->second.name)
+                    continue;
+
+                auto &deps = dependencies[component.id.value];
+                deps.insert(dep_components.begin(), dep_components.end());
+                deps.erase(component.id.value);
+            }
+        }
 
         os << "{\n";
         indent(os, 2);
@@ -94,7 +137,6 @@ namespace depbridge::sbom
         indent(os, 2);
         os << "\"version\": 1,\n";
 
-        // Metadata
         indent(os, 2);
         os << "\"metadata\": {\n";
         indent(os, 4);
@@ -104,13 +146,30 @@ namespace depbridge::sbom
         indent(os, 6);
         os << "\"name\": \"cpp-dep-bridge\",\n";
         indent(os, 6);
-        os << "\"version\": \"0.1.0-dev\"\n";
+        os << "\"version\": \"" << json_escape(depbridge::version) << "\"\n";
         indent(os, 4);
-        os << "}]\n";
+        os << "}]";
+
+        if (const auto subject = resolve_metadata_subject(g); subject.has_value())
+        {
+            os << ",\n";
+            indent(os, 4);
+            os << "\"component\": {\n";
+            indent(os, 6);
+            const Component *subject_component = *subject;
+            os << "\"type\": \"" << component_type_to_cdx(subject_component->type) << "\",\n";
+            indent(os, 6);
+            os << "\"bom-ref\": \"" << json_escape(subject_component->id.value) << "\",\n";
+            indent(os, 6);
+            os << "\"name\": \"" << json_escape(subject_component->name) << "\"\n";
+            indent(os, 4);
+            os << "}";
+        }
+
+        os << "\n";
         indent(os, 2);
         os << "},\n";
 
-        // Components
         indent(os, 2);
         os << "\"components\": [\n";
 
@@ -162,6 +221,48 @@ namespace depbridge::sbom
             os << "}";
 
             if (i + 1 < comps.size())
+                os << ",";
+            os << "\n";
+        }
+
+        indent(os, 2);
+        os << "],\n";
+
+        indent(os, 2);
+        os << "\"dependencies\": [\n";
+
+        std::vector<std::string> dep_refs;
+        dep_refs.reserve(comps.size());
+        for (const auto *comp : comps)
+            dep_refs.push_back(comp->id.value);
+
+        for (std::size_t i = 0; i < dep_refs.size(); ++i)
+        {
+            const auto &ref = dep_refs[i];
+            indent(os, 4);
+            os << "{\n";
+            indent(os, 6);
+            os << "\"ref\": \"" << json_escape(ref) << "\",\n";
+            indent(os, 6);
+            os << "\"dependsOn\": [";
+
+            std::vector<std::string> sorted_deps;
+            if (const auto it = dependencies.find(ref); it != dependencies.end())
+            {
+                sorted_deps.assign(it->second.begin(), it->second.end());
+            }
+
+            for (std::size_t di = 0; di < sorted_deps.size(); ++di)
+            {
+                if (di > 0)
+                    os << ", ";
+                os << "\"" << json_escape(sorted_deps[di]) << "\"";
+            }
+
+            os << "]\n";
+            indent(os, 4);
+            os << "}";
+            if (i + 1 < dep_refs.size())
                 os << ",";
             os << "\n";
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,3 +46,12 @@ add_test(
 add_executable(depbridge_unit_classify unit/test_classify.cpp)
 target_link_libraries(depbridge_unit_classify PRIVATE depbridge::core)
 add_test(NAME depbridge.unit.classify COMMAND depbridge_unit_classify)
+
+
+add_executable(depbridge_unit_file_api_ingestor unit/test_file_api_ingestor.cpp)
+target_link_libraries(depbridge_unit_file_api_ingestor PRIVATE depbridge::core)
+add_test(NAME depbridge.unit.file_api_ingestor COMMAND depbridge_unit_file_api_ingestor)
+
+add_executable(depbridge_unit_file_api_no_guessing unit/test_file_api_no_guessing.cpp)
+target_link_libraries(depbridge_unit_file_api_no_guessing PRIVATE depbridge::core)
+add_test(NAME depbridge.unit.file_api_no_guessing COMMAND depbridge_unit_file_api_no_guessing)

--- a/tests/unit/test_classify.cpp
+++ b/tests/unit/test_classify.cpp
@@ -17,6 +17,9 @@ static void test_system_classification()
 #else
     sys.name = "pthread";
 #endif
+    // v0.4 classification is evidence-gated: known system names only classify
+    // when we also have explicit system/link evidence.
+    sys.sources.push_back(SourceRef{"cmake-link-token", sys.name, std::nullopt});
     sys.id = component_id_of(sys);
     g.components[sys.id.value] = sys;
 
@@ -33,13 +36,7 @@ static void test_system_classification()
 
     classify_system_components(g);
 
-#if defined(_WIN32)
     assert(g.components[sys.id.value].origin == ComponentOrigin::system);
-#else
-    assert(
-        g.components[sys.id.value].origin == ComponentOrigin::system ||
-        g.components[sys.id.value].origin == ComponentOrigin::unknown);
-#endif
 
     assert(g.components[proj.id.value].origin == ComponentOrigin::project_local);
     assert(g.components[third.id.value].origin == ComponentOrigin::unknown);
@@ -50,7 +47,8 @@ static void test_third_party_imported_target()
     ProjectGraph g;
 
     Component c;
-    c.name = "fmt::fmt";
+    c.name = "fmt";
+    c.sources.push_back(SourceRef{"cmake-imported", "fmt::fmt", std::nullopt});
     c.id = component_id_of(c);
     g.components[c.id.value] = c;
 
@@ -96,6 +94,22 @@ static void test_third_party_does_not_override()
     assert(g.components[sys.id.value].origin == ComponentOrigin::system);
 }
 
+
+static void test_ambiguous_remains_unknown_without_evidence()
+{
+    ProjectGraph g;
+
+    Component c;
+    c.name = "maybe_external";
+    c.id = component_id_of(c);
+    g.components[c.id.value] = c;
+
+    classify_system_components(g);
+    classify_third_party_components(g);
+
+    assert(g.components[c.id.value].origin == ComponentOrigin::unknown);
+}
+
 int main()
 {
     ProjectGraph g;
@@ -133,6 +147,7 @@ int main()
     test_third_party_imported_target();
     test_third_party_source_ref();
     test_third_party_does_not_override();
+    test_ambiguous_remains_unknown_without_evidence();
 
     return 0;
 }

--- a/tests/unit/test_cyclonedx.cpp
+++ b/tests/unit/test_cyclonedx.cpp
@@ -1,6 +1,7 @@
 #include "depbridge/sbom/cyclonedx_writer.hpp"
 #include "depbridge/model/ids.hpp"
 #include "depbridge/model/types.hpp"
+#include "depbridge/version.hpp"
 
 #include <cassert>
 #include <iostream>
@@ -15,20 +16,31 @@ static ProjectGraph make_graph()
     g.context.root_directory = "root";
     g.context.build_directory = "build";
 
-    Component a;
-    a.type = ComponentType::library;
-    a.name = "fmt";
-    a.version = "10.2.1";
-    a.purl = "pkg:github/fmtlib/fmt@10.2.1";
-    a.license.spdx_id = "MIT";
-    a.id = component_id_of(a);
-    g.components[a.id.value] = a;
+    BuildTarget app_target;
+    app_target.id = TargetId{"tgt:app"};
+    app_target.name = "app";
+    g.targets[app_target.id.value] = app_target;
 
-    Component b;
-    b.type = ComponentType::unknown;
-    b.name = "OpenSSL::SSL";
-    b.id = component_id_of(b);
-    g.components[b.id.value] = b;
+    Component app;
+    app.type = ComponentType::executable;
+    app.name = "app";
+    app.origin = ComponentOrigin::project_local;
+    app.id = component_id_of(app);
+    g.components[app.id.value] = app;
+
+    Component fmt;
+    fmt.type = ComponentType::library;
+    fmt.name = "fmt";
+    fmt.version = "10.2.1";
+    fmt.purl = "pkg:github/fmtlib/fmt@10.2.1";
+    fmt.license.spdx_id = "MIT";
+    fmt.id = component_id_of(fmt);
+    g.components[fmt.id.value] = fmt;
+
+    DependencyEdge edge;
+    edge.from = app_target.id;
+    edge.to_component = fmt.id;
+    g.edges.push_back(edge);
 
     return g;
 }
@@ -42,58 +54,27 @@ static void test_cyclonedx_is_deterministic()
     assert(o1.str() == o2.str());
 }
 
-static void test_cyclonedx_contains_components_and_fields()
+static void test_cyclonedx_contains_metadata_and_dependencies()
 {
     auto g = make_graph();
     std::ostringstream os;
     depbridge::sbom::write_cyclonedx_json(os, g);
     const std::string s = os.str();
 
-    // Required top-level fields
     assert(s.find("\"bomFormat\": \"CycloneDX\"") != std::string::npos);
-    assert(s.find("\"specVersion\": \"1.5\"") != std::string::npos);
-    assert(s.find("\"components\": [") != std::string::npos);
+    assert(s.find("\"version\": \"" + std::string(depbridge::version) + "\"") != std::string::npos);
+    assert(s.find("\"metadata\"") != std::string::npos);
+    assert(s.find("\"component\"") != std::string::npos);
 
-    // fmt component fields
-    assert(s.find("\"name\": \"fmt\"") != std::string::npos);
-    assert(s.find("\"version\": \"10.2.1\"") != std::string::npos);
-    assert(s.find("\"purl\": \"pkg:github/fmtlib/fmt@10.2.1\"") != std::string::npos);
-    assert(s.find("\"licenses\":") != std::string::npos);
-    assert(s.find("\"id\": \"MIT\"") != std::string::npos);
-
-    // OpenSSL::SSL present (unknown type maps to library in MVP)
-    assert(s.find("\"name\": \"OpenSSL::SSL\"") != std::string::npos);
-
-    assert(s.find("\"name\": \"depbridge:origin\"") != std::string::npos);
-    assert(s.find("\"value\": \"unknown\"") != std::string::npos);
-}
-
-static void test_cyclonedx_components_sorted_by_id()
-{
-    auto g = make_graph();
-    std::ostringstream os;
-    depbridge::sbom::write_cyclonedx_json(os, g);
-    const std::string s = os.str();
-
-    // Components are sorted by ComponentId (bom-ref)
-    auto it = g.components.begin();
-    std::string first_id = it->first;
-    ++it;
-    std::string second_id = it->first;
-
-    assert(first_id < second_id);
-
-    const auto p1 = s.find(first_id);
-    const auto p2 = s.find(second_id);
-    assert(p1 != std::string::npos && p2 != std::string::npos);
-    assert(p1 < p2);
+    assert(s.find("\"dependencies\": [") != std::string::npos);
+    assert(s.find("\"dependsOn\": [\"" + g.components.begin()->first) != std::string::npos ||
+           s.find("\"dependsOn\": [\"cmp_") != std::string::npos);
 }
 
 int main()
 {
     test_cyclonedx_is_deterministic();
-    test_cyclonedx_contains_components_and_fields();
-    test_cyclonedx_components_sorted_by_id();
+    test_cyclonedx_contains_metadata_and_dependencies();
 
     std::cout << "[unit] cyclonedx: OK\n";
     return 0;

--- a/tests/unit/test_file_api_ingestor.cpp
+++ b/tests/unit/test_file_api_ingestor.cpp
@@ -1,0 +1,34 @@
+#include "depbridge/ingest/cmake/file_api_ingestor.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+static void test_deterministic_index_selection_is_stable()
+{
+    using depbridge::ingest::cmake::select_deterministic_file_api_index;
+
+    std::vector<std::filesystem::path> a = {
+        "/tmp/reply/index-aaa.json",
+        "/tmp/reply/index-zzz.json",
+        "/tmp/reply/index-mid.json",
+    };
+    std::vector<std::filesystem::path> b = {
+        "/tmp/reply/index-mid.json",
+        "/tmp/reply/index-aaa.json",
+        "/tmp/reply/index-zzz.json",
+    };
+
+    const auto chosen_a = select_deterministic_file_api_index(a);
+    const auto chosen_b = select_deterministic_file_api_index(b);
+
+    assert(chosen_a.filename() == "index-zzz.json");
+    assert(chosen_b.filename() == "index-zzz.json");
+}
+
+int main()
+{
+    test_deterministic_index_selection_is_stable();
+    std::cout << "[unit] file_api_ingestor: OK\n";
+    return 0;
+}

--- a/tests/unit/test_file_api_no_guessing.cpp
+++ b/tests/unit/test_file_api_no_guessing.cpp
@@ -1,0 +1,70 @@
+#include "depbridge/ingest/cmake/file_api_ingestor.hpp"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+static void write_file(const std::filesystem::path &p, const std::string &content)
+{
+    std::filesystem::create_directories(p.parent_path());
+    std::ofstream out(p);
+    out << content;
+}
+
+static void test_ingest_does_not_emit_guess_sources()
+{
+    namespace fs = std::filesystem;
+    const fs::path base = fs::temp_directory_path() / "depbridge_file_api_no_guessing";
+    fs::remove_all(base);
+
+    const fs::path reply = base / ".cmake" / "api" / "v1" / "reply";
+
+    write_file(reply / "index-0001.json", R"({
+      "objects": [
+        {"kind":"codemodel","version":{"major":2},"jsonFile":"codemodel-v2.json"}
+      ]
+    })");
+
+    write_file(reply / "codemodel-v2.json", R"({
+      "configurations": [
+        {
+          "name": "Debug",
+          "targets": [
+            {"jsonFile":"target-app.json"}
+          ]
+        }
+      ]
+    })");
+
+    write_file(reply / "target-app.json", R"({
+      "name": "app",
+      "id": "app::id",
+      "artifacts": [],
+      "link": {
+        "libraries": [
+          {"path":"C:/vcpkg/installed/x64-windows/lib/fmtd.lib"}
+        ]
+      }
+    })");
+
+    auto g = depbridge::ingest::cmake::ingest_file_api(base, {});
+    assert(!g.edges.empty());
+    for (const auto &edge : g.edges)
+    {
+        for (const auto &src : edge.sources)
+        {
+            assert(src.system != "vcpkg");
+            assert(src.ref.find("guess:") == std::string::npos);
+        }
+    }
+
+    fs::remove_all(base);
+}
+
+int main()
+{
+    test_ingest_does_not_emit_guess_sources();
+    std::cout << "[unit] file_api_no_guessing: OK\n";
+    return 0;
+}

--- a/tests/unit/test_normalize.cpp
+++ b/tests/unit/test_normalize.cpp
@@ -30,7 +30,8 @@ static void test_token_to_component_cmake_target_passthrough()
 {
     NormalizeOptions opt;
     auto c = component_from_link_token("OpenSSL::SSL", opt);
-    assert(c.name == "OpenSSL::SSL");
+    assert(c.name == "OpenSSL");
+    assert(c.properties.at("cmake.target") == "OpenSSL::SSL");
     assert(c.type == ComponentType::library);
 }
 
@@ -109,13 +110,13 @@ static void test_imported_cmake_targets_create_components()
     NormalizeOptions opt;
     normalize_graph(g, opt);
 
-    // We should get one component per imported target (no namespace collapsing).
+    // Imported targets normalize to package-level components.
     assert(g.components.size() == 2);
 
     {
         Component c;
         c.type = ComponentType::library;
-        c.name = "fmt::fmt";
+        c.name = "fmt";
         const ComponentId expected = component_id_of(c);
         assert(g.components.count(expected.value) == 1);
     }
@@ -123,7 +124,7 @@ static void test_imported_cmake_targets_create_components()
     {
         Component c;
         c.type = ComponentType::library;
-        c.name = "nlohmann_json::nlohmann_json";
+        c.name = "nlohmann_json";
         const ComponentId expected = component_id_of(c);
         assert(g.components.count(expected.value) == 1);
     }
@@ -136,6 +137,17 @@ static void test_imported_cmake_targets_create_components()
     assert(g.components.count(g.edges[1].to_component->value) == 1);
 }
 
+
+static void test_ambiguous_non_path_tokens_do_not_collapse()
+{
+    NormalizeOptions opt;
+    auto a = component_from_link_token("libcrypto", opt);
+    auto b = component_from_link_token("crypto", opt);
+    assert(a.name == "libcrypto");
+    assert(b.name == "crypto");
+    assert(a.id.value != b.id.value);
+}
+
 int main()
 {
     test_token_to_component_unix_dash_l();
@@ -144,6 +156,7 @@ int main()
     test_merge_component_fills_missing();
     test_normalize_graph_merges_duplicates_and_remaps_edges();
     test_imported_cmake_targets_create_components();
+    test_ambiguous_non_path_tokens_do_not_collapse();
 
     std::cout << "[unit] normalize: OK\n";
     return 0;


### PR DESCRIPTION
…classification, SBOM dependencies (#16)

* Refactor File API ingestion and harden determinism for v0.4 alpha

* Fix CycloneDX metadata subject pointer handling

* Fix classify unit test for evidence-gated system origin